### PR TITLE
Link with udev

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(hidapi-hidraw hid.c)
+target_link_libraries(hidapi-hidraw udev)


### PR DESCRIPTION
While it works fine to link with udev later, the build will break if you
use more extreme linker flags with undefined references to libudev.