### PR TITLE
Add Sixaxis init for Monterey

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -495,6 +495,14 @@ extern "C" {
 		*/
 		int HID_API_EXPORT HID_API_CALL hid_write_control(hid_device *device, const unsigned char *data, size_t length);
 
+#ifdef __APPLE__
+		/** RPCS3 EDIT: Initializes a USB Sixaxis/DualShock 3 controller,
+		 *  which requires report_id to be separate from the data packet.
+		 *  Required on macOS Monterey.
+		 */
+		int HID_API_EXPORT hid_init_sixaxis_usb(hid_device *dev);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1203,6 +1203,18 @@ HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 	return L"hid_error is not implemented yet";
 }
 
+int HID_API_EXPORT hid_init_sixaxis_usb(hid_device *dev)
+{
+	const char data[] = { 0x42, 0x0C, 0x00, 0x00 };
+	size_t length = sizeof(data);
+	const unsigned char report_id = 0xF4;
+
+	if (IOHIDDeviceSetReport(dev->device_handle, kIOHIDReportTypeFeature, report_id, data, length) == kIOReturnSuccess) {
+		return length;
+	}
+
+	return -1;
+}
 
 
 


### PR DESCRIPTION
macOS 12 doesn't initialize Sixaxis/DS3 controllers properly.
The existing HID functions cannot be used to initialize the controller because, unlike any other HID device, the report ID is different than the first data byte.