### PR TITLE
hid_open_path: Don't pass invalid pointers to HidD_FreePreparsedData

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -862,7 +862,10 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 
 end_of_function:
 	CloseHandle(device_handle);
-	HidD_FreePreparsedData(pp_data);
+
+	if (pp_data) {
+		HidD_FreePreparsedData(pp_data);
+	}
 
 	return dev;
 }


### PR DESCRIPTION
Fixes a segfault that happens when hid_open_path is called on a previously disconnected device.
This is a regression caused by:
b600727 - Win32: Fix memory leak in `free_hid_device` (#361)