### PR TITLE
hid.c: Fix reinitialization after an error

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -136,8 +136,8 @@ static void register_error_str(wchar_t **error_str, const char *msg)
 /* Semilar to register_error_str, but allows passing a format string with va_list args into this function. */
 static void register_error_str_vformat(wchar_t **error_str, const char *format, va_list args)
 {
-	char msg[256];
-	vsnprintf(msg, sizeof(msg), format, args);
+	char* msg = (char*)malloc(256);
+	vsnprintf(msg, 256, format, args);
 
 	register_error_str(error_str, msg);
 }


### PR DESCRIPTION
This should fix the crashes I experienced whenever DuelSense and DuelShock 4 got disconnected from bluetooth, either by battery shortage or manual shutdown from the controller.
The bug occured because data from the stack was used instead of dynamic memory to output the error after device connection errors, upon reinitialization (in an attempt to reconnect with the controller) the function got called again to clean the error buffer, but it called the C function `free` with an invalid pointer.
The crash occured inside of the `free` function.