### PR TITLE
Updated CMake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     add_subdirectory(src)


### PR DESCRIPTION
Updated `cmake_minimum_required(VERSION 3.1.3 FATAL_ERROR)` in hidapi to `cmake_minimum_required(VERSION 3.5 FATAL_ERROR)`.